### PR TITLE
Add implementation for governance token template and token factory

### DIFF
--- a/contracts/OctobayGovToken.sol
+++ b/contracts/OctobayGovToken.sol
@@ -32,7 +32,7 @@ contract OctobayGovToken is OctobayStorage, ERC20 {
     }
 
     /// @notice Explicitly disabling transfers by individual owners 
-    function transfer(address recipient, uint256 amount) public override returns (bool) {
+    function transfer(address, uint256) public override returns (bool) {
         require(false, "Transfers are only allowed by the Octobay contract");
     }
 }

--- a/contracts/OctobayGovToken.sol
+++ b/contracts/OctobayGovToken.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+import './OctobayStorage.sol';
+
+contract OctobayGovToken is OctobayStorage, ERC20 {
+
+    /// @param _name Name of the new token
+    /// @param _symbol Token Symbol for the new token
+    constructor(string memory _name, string memory _symbol) ERC20(_name, _symbol) public {}
+
+    /// @param _to Address of recipient for new tokens
+    /// @param _amount Amount of new tokens to create
+    function mint(address _to, uint256 _amount) external onlyOctobay {
+        _mint(_to, _amount);
+    }
+
+    /// @param _from Address from whose tokens will be destroyed
+    /// @param _amount Amount of tokens to destroy
+    function burn(address _from, uint256 _amount) external onlyOctobay {
+        _burn(_from, _amount);
+    }
+
+    /// @param _sender Address from whose tokens will be taken
+    /// @param _recipient Address of who will receive the tokens
+    /// @param _amount Amount of tokens to send
+    function transferFrom(address _sender, address _recipient, uint256 _amount) public override onlyOctobay returns (bool) {
+        _transfer(_sender, _recipient, _amount);
+        return true;
+    }
+
+    /// @notice Explicitly disabling transfers by individual owners 
+    function transfer(address recipient, uint256 amount) public override returns (bool) {
+        require(false, "Transfers are only allowed by the Octobay contract");
+    }
+}

--- a/contracts/OctobayGovTokenFactory.sol
+++ b/contracts/OctobayGovTokenFactory.sol
@@ -8,14 +8,29 @@ import './OctobayGovToken.sol';
 contract OctobayGovTokenFactory is OctobayStorage {
 
     event NewTokenEvent(string name, string symbol, address tokenAddr);
+    event UpdatedProjectId(string oldProjectId, string newProjectId);
+    mapping (string => address) public tokensByProjectId;
 
     /// @param _name Name of the new token
     /// @param _symbol Token Symbol for the new token
+    /// @param _projectId Path of the org or repo which maps to the new token
     /// @return The address of the new token contract
-    function createToken(string memory _name, string memory _symbol) external onlyOctobay returns (OctobayGovToken) {
+    function createToken(string memory _name, string memory _symbol, string memory _projectId) external onlyOctobay returns (OctobayGovToken) {
         OctobayGovToken newToken = new OctobayGovToken(_name, _symbol);
         newToken.setOctobay(msg.sender);
+        tokensByProjectId[_projectId] = address(newToken);
         emit NewTokenEvent(_name, _symbol, address(newToken));
         return newToken;
+    }
+
+    /// @notice Used in case a project wants to transfer tokens from a repo to an org in the future for example
+    /// @param _oldProjectId Path of the old org or repo which should be updated
+    /// @param _newProjectId Path of the new org or repo which should be used
+    function updateProjectId(string memory _oldProjectId, string memory _newProjectId) external onlyOctobay {
+        require(tokensByProjectId[_oldProjectId] != address(0), "Existing repo or org does not exist");
+        address tokenAddr = tokensByProjectId[_oldProjectId];
+        delete tokensByProjectId[_oldProjectId];
+        tokensByProjectId[_newProjectId] = tokenAddr;
+        emit UpdatedProjectId(_oldProjectId, _newProjectId);
     }    
 }

--- a/contracts/OctobayGovTokenFactory.sol
+++ b/contracts/OctobayGovTokenFactory.sol
@@ -7,12 +7,15 @@ import './OctobayGovToken.sol';
 
 contract OctobayGovTokenFactory is OctobayStorage {
 
+    event NewTokenEvent(string name, string symbol);
+
     /// @param _name Name of the new token
     /// @param _symbol Token Symbol for the new token
     /// @return The address of the new token contract
     function createToken(string memory _name, string memory _symbol) external onlyOctobay returns (OctobayGovToken) {
         OctobayGovToken newToken = new OctobayGovToken(_name, _symbol);
         newToken.setOctobay(msg.sender);
+        emit NewTokenEvent(_name, _symbol);
         return newToken;
     }    
 }

--- a/contracts/OctobayGovTokenFactory.sol
+++ b/contracts/OctobayGovTokenFactory.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import './OctobayStorage.sol';
+import './OctobayGovToken.sol';
+
+contract OctobayGovTokenFactory is OctobayStorage {
+
+    /// @param _name Name of the new token
+    /// @param _symbol Token Symbol for the new token
+    /// @return The address of the new token contract
+    function createToken(string memory _name, string memory _symbol) external onlyOctobay returns (OctobayGovToken) {
+        OctobayGovToken newToken = new OctobayGovToken(_name, _symbol);
+        newToken.setOctobay(msg.sender);
+        return newToken;
+    }    
+}

--- a/contracts/OctobayGovTokenFactory.sol
+++ b/contracts/OctobayGovTokenFactory.sol
@@ -7,7 +7,7 @@ import './OctobayGovToken.sol';
 
 contract OctobayGovTokenFactory is OctobayStorage {
 
-    event NewTokenEvent(string name, string symbol);
+    event NewTokenEvent(string name, string symbol, address tokenAddr);
 
     /// @param _name Name of the new token
     /// @param _symbol Token Symbol for the new token
@@ -15,7 +15,7 @@ contract OctobayGovTokenFactory is OctobayStorage {
     function createToken(string memory _name, string memory _symbol) external onlyOctobay returns (OctobayGovToken) {
         OctobayGovToken newToken = new OctobayGovToken(_name, _symbol);
         newToken.setOctobay(msg.sender);
-        emit NewTokenEvent(_name, _symbol);
+        emit NewTokenEvent(_name, _symbol, address(newToken));
         return newToken;
     }    
 }


### PR DESCRIPTION
This is intended to cover: 
#4 
#5 

Things to consder:

- Do we want to explicitly disable the allowance (approval) related functions inherited from ERC20? (Probably)
- Where are we storing the list of Tokens created? In the factory or a separate contract?
- Where is the mapping to the org/repo stored?

TO DO:

- [ ] Add appropriate events to track token creation
- [ ] implement `balanceOfAt(uint256 blocknumber)`