### PR TITLE
Addition of an NFT for governance permissions

### DIFF
--- a/contracts/Octobay.sol
+++ b/contracts/Octobay.sol
@@ -496,9 +496,7 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
         octobayGovernor.createToken(newToken.name, newToken.symbol, newToken.projectId);
         octobayGovernor.createGovernor(newToken.projectId, newToken.newProposalShare);
         uint256 nftId = octobayGovNFT.mintTokenForProject(newToken.creator, newToken.projectId);
-        // Can set other permissions here
-        octobayGovNFT.grantPermission(nftId, OctobayGovNFT.Permission.SET_ISSUE_GOVTOKEN);
-        octobayGovNFT.grantPermission(nftId, OctobayGovNFT.Permission.CREATE_PROPOSAL);
+        octobayGovNFT.grantAllPermissions(nftId);
     }
 
     function awardGovernanceTokens(address recipient, uint256 payoutEth, OctobayGovToken tokenAddr) internal {

--- a/contracts/Octobay.sol
+++ b/contracts/Octobay.sol
@@ -498,6 +498,7 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
         uint256 nftId = octobayGovNFT.mintTokenForProject(newToken.creator, newToken.projectId);
         // Can set other permissions here
         octobayGovNFT.grantPermission(nftId, OctobayGovNFT.Permission.SET_ISSUE_GOVTOKEN);
+        octobayGovNFT.grantPermission(nftId, OctobayGovNFT.Permission.CREATE_PROPOSAL);
     }
 
     function awardGovernanceTokens(address recipient, uint256 payoutEth, OctobayGovToken tokenAddr) internal {

--- a/contracts/Octobay.sol
+++ b/contracts/Octobay.sol
@@ -346,7 +346,12 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
     mapping(string => IssueStatus) public issueStatusByIssueId;
     mapping(string => OctobayGovToken) public govTokenByIssueId;
 
-    function setGovTokenForIssue(string calldata _issueId, address _govTokenAddress, string calldata _projectId) external {
+    function depositAndSetGovTokenForIssue(string calldata _issueId, address _govTokenAddress, string calldata _projectId) external {
+        depositEthForIssue(_issueId);
+        setGovTokenForIssue(_issueId, _govTokenAddress, _projectId);
+    }
+
+    function setGovTokenForIssue(string calldata _issueId, address _govTokenAddress, string calldata _projectId) public {
         require(issueStatusByIssueId[_issueId] == IssueStatus.OPEN, 'Issue is not OPEN.');
         // Ensure they're giving us a valid gov token
         require(address(octobayGovernor.tokensByProjectId(_projectId)) == _govTokenAddress, "_projectId is not associated with _govTokenAddress");
@@ -361,7 +366,7 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
         govTokenByIssueId[_issueId] = OctobayGovToken(_govTokenAddress);
     }
 
-    function depositEthForIssue(string calldata _issueId) external payable {
+    function depositEthForIssue(string calldata _issueId) public payable {
         require(msg.value > 0, 'You must send ETH.');
         require(issueStatusByIssueId[_issueId] == IssueStatus.OPEN, 'Issue is not OPEN.');
 

--- a/contracts/Octobay.sol
+++ b/contracts/Octobay.sol
@@ -498,8 +498,7 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
         require(newToken.isValue, "No such request");
         delete newGovernanceTokenReqs[_requestId];
 
-        octobayGovernor.createToken(newToken.name, newToken.symbol, newToken.projectId);
-        octobayGovernor.createGovernor(newToken.projectId, newToken.newProposalShare);
+        octobayGovernor.createGovernorAndToken(newToken.projectId, newToken.newProposalShare, newToken.name, newToken.symbol);
         uint256 nftId = octobayGovNFT.mintTokenForProject(newToken.creator, newToken.projectId);
         octobayGovNFT.grantAllPermissions(nftId);
     }

--- a/contracts/OctobayGovNFT.sol
+++ b/contracts/OctobayGovNFT.sol
@@ -83,4 +83,8 @@ contract OctobayGovNFT is OctobayStorage, ERC721Pausable {
             _grantPermission(newTokenId, _perms[i]);
         }
     }
+
+    function burn(uint256 _tokenId) public {
+        _burn(_tokenId);
+    }
 }

--- a/contracts/OctobayGovNFT.sol
+++ b/contracts/OctobayGovNFT.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
+import './OctobayStorage.sol';
+
+contract OctobayGovNFT is OctobayStorage, ERC721 {
+    enum Permission {
+        TRANSFER,
+        COPY,
+        SET_ISSUE_GOVTOKEN,
+        CREATE_PROPOSAL
+        // e.t.c.
+    }
+
+    mapping (uint256 => mapping (uint => bool) ) public permissionsByTokenID;
+    mapping (uint256 => string) public projectIdsByTokenID;
+
+    constructor(string memory name, string memory symbol) public ERC721(name, symbol) {}
+
+    function hasPermission(uint256 _tokenId, Permission _perm) public view returns(bool) {
+        return permissionsByTokenID[_tokenId][uint(_perm)];
+    }
+
+    function grantPermission(uint256 _tokenId, Permission _perm) external onlyOctobay {
+        permissionsByTokenID[_tokenId][uint(_perm)] = true;
+    }
+
+    function revokePermission(uint256 _tokenId, Permission _perm) external onlyOctobay {
+        permissionsByTokenID[_tokenId][uint(_perm)] = false;
+    }
+
+    function mintTokenForProject(address _to, string memory _projectId) external onlyOctobay returns(uint256) {
+        uint256 tokenId = totalSupply() + 1;
+        _safeMint(_to, tokenId);
+        projectIdsByTokenID[tokenId] = _projectId;
+        return tokenId;
+    }
+
+    function getTokenIDForUserInProject(address _user, string memory _projectId) public view returns(uint256) {
+        for (uint i=0; i < balanceOf(_user); i++) {
+            if (keccak256(bytes(projectIdsByTokenID[tokenOfOwnerByIndex(_user, i)])) == keccak256(bytes(_projectId))) {
+                return tokenOfOwnerByIndex(_user, i);
+            }
+        }
+
+        return 0;
+    }
+}

--- a/contracts/OctobayGovernor.sol
+++ b/contracts/OctobayGovernor.sol
@@ -56,8 +56,13 @@ contract OctobayGovernor is OctobayStorage {
         octobayGovNFT = OctobayGovNFT(_octobayGovNFT);
     }
 
+    function createGovernorAndToken(string memory _projectId, uint16 _newProposalShare, string memory _name, string memory _symbol) external onlyOctobay {
+        createGovernor(_projectId, _newProposalShare);
+        createToken(_name, _symbol, _projectId);
+    } 
+
     /// @dev Necessary to set the newProposalShare for new proposals and to know if we've already initialized a governor
-    function createGovernor(string memory _projectId, uint16 _newProposalShare) external onlyOctobay {
+    function createGovernor(string memory _projectId, uint16 _newProposalShare) public onlyOctobay {
         require(!governorsByProjectId[_projectId].isValue, "Governor for that _projectId already exists");
         Governor memory newGovernor = Governor({
             isValue: true,
@@ -155,7 +160,7 @@ contract OctobayGovernor is OctobayStorage {
     /// @param _symbol Token Symbol for the new token
     /// @param _projectId Path of the org or repo which maps to the new token
     /// @return The address of the new token contract
-    function createToken(string memory _name, string memory _symbol, string memory _projectId) external onlyOctobay returns (OctobayGovToken) {
+    function createToken(string memory _name, string memory _symbol, string memory _projectId) public onlyOctobay returns (OctobayGovToken) {
         OctobayGovToken newToken = new OctobayGovToken(_name, _symbol);
         newToken.setOctobay(msg.sender);
         tokensByProjectId[_projectId] = newToken;

--- a/migrations/24_octobay_gov_nft.js
+++ b/migrations/24_octobay_gov_nft.js
@@ -1,7 +1,7 @@
 require("dotenv").config({ path: './../.env' })
-const OctobayGovernor = artifacts.require("OctobayGovernor")
+const OctobayGovNFT = artifacts.require("OctobayGovNFT")
 
 module.exports = function (deployer, network) {
   if (network == 'test') return;
-  deployer.deploy(OctobayGovernor)
+  deployer.deploy(OctobayGovNFT)
 }

--- a/migrations/25_octobay_governor.js
+++ b/migrations/25_octobay_governor.js
@@ -1,0 +1,8 @@
+require("dotenv").config({ path: './../.env' })
+const OctobayGovernor = artifacts.require("OctobayGovernor")
+const OctobayGovNFT = artifacts.require("OctobayGovNFT")
+
+module.exports = function (deployer, network) {
+  if (network == 'test') return;
+  deployer.deploy(OctobayGovernor, OctobayGovNFT.address)
+}

--- a/migrations/30_octobay.js
+++ b/migrations/30_octobay.js
@@ -40,7 +40,7 @@ module.exports = function (deployer, network) {
       OctobayGovernor.deployed().then(OctobayGovernorInstance => {
         OctobayGovernorInstance.setOctobay(octobayInstance.address)
       })     
-      OctobayGovNFT.deployed(OctobayGovNFTInstance => {
+      OctobayGovNFT.deployed().then(OctobayGovNFTInstance => {
         OctobayGovNFTInstance.setOctobay(octobayInstance.address)
       })       
     })

--- a/migrations/30_octobay.js
+++ b/migrations/30_octobay.js
@@ -6,6 +6,7 @@ const OctobayVisibilityToken = artifacts.require("OctobayVisibilityToken")
 const UserAddressStorage = artifacts.require("UserAddressStorage")
 const OracleStorage = artifacts.require("OracleStorage")
 const OctobayGovernor = artifacts.require("OctobayGovernor")
+const OctobayGovNFT = artifacts.require("OctobayGovNFT")
 const zeroAddress = "0x0000000000000000000000000000000000000000"
 
 module.exports = function (deployer, network) {
@@ -19,7 +20,8 @@ module.exports = function (deployer, network) {
       UserAddressStorage.address,
       OracleStorage.address,
       OctobayGovernor.address,
-      zeroAddress
+      zeroAddress,
+      OctobayGovNFT.address
     ).then(octobayInstance => {
       octobayInstance.setTwitterAccountId(process.env.OCTOBAY_TWITTER_ACCOUNT_ID)
       LinkToken.deployed().then(linkTokenInstance => {
@@ -37,7 +39,10 @@ module.exports = function (deployer, network) {
       })
       OctobayGovernor.deployed(OctobayGovernorInstance => {
         OctobayGovernorInstance.setOctobay(octobayInstance.address)
-      })      
+      })     
+      OctobayGovNFT.deployed(OctobayGovNFTInstance => {
+        OctobayGovNFTInstance.setOctobay(octobayInstance.address)
+      })       
     })
   } else if (network == 'kovan') {
     deployer.deploy(
@@ -48,7 +53,8 @@ module.exports = function (deployer, network) {
       UserAddresses.address,
       Oracles.address,
       OctobayGovernor.address,
-      '0x9326BFA02ADD2366b30bacB125260Af641031331'
+      '0x9326BFA02ADD2366b30bacB125260Af641031331',
+      OctobayGovNFT.address
     )
   }
 }


### PR DESCRIPTION
This PR attempts to cover a few more things left out in #7

An NFT is minted and given to the creator of a new governance token for a project. This NFT is then given permissions which allow the holder to:
* set the governance token on bounties
* create proposals
e.t.c.
