### PR TITLE
Add a few more events for governance

### DIFF
--- a/contracts/Octobay.sol
+++ b/contracts/Octobay.sol
@@ -326,6 +326,7 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
 
     event IssueDepositEvent(address from, uint256 amount, string issueId, uint256 depositId);
     event RefundIssueDepositEvent(address to, uint256 amount, string issueId, uint256 depositId);
+    event SetGovTokenForIssueEvent(address from, string  issueId, address govTokenAddress, string projectId);
 
     enum IssueStatus {
         // NOT_VALID, // There's no sense of 'opening' an issue atm, this would be used if so
@@ -364,6 +365,7 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
         }
         require(hasPermission, "You don't have permission to set governance tokens for issues");
         govTokenByIssueId[_issueId] = OctobayGovToken(_govTokenAddress);
+        emit SetGovTokenForIssueEvent(msg.sender, _issueId, _govTokenAddress, _projectId);
     }
 
     function depositEthForIssue(string calldata _issueId) public payable {

--- a/contracts/OctobayGovNFT.sol
+++ b/contracts/OctobayGovNFT.sol
@@ -14,6 +14,9 @@ contract OctobayGovNFT is OctobayStorage, ERC721Pausable {
         // e.t.c.
     }
 
+    event MintTokenForProjectEvent(address to, string projectId, uint256 tokenId);
+    event BurnTokenEvent(uint256 tokenId);
+
     mapping (uint256 => mapping (uint => bool) ) public permissionsByTokenID;
     mapping (uint256 => string) public projectIdsByTokenID;
 
@@ -54,6 +57,7 @@ contract OctobayGovNFT is OctobayStorage, ERC721Pausable {
         uint256 tokenId = totalSupply() + 1;
         _safeMint(_to, tokenId);
         projectIdsByTokenID[tokenId] = _projectId;
+        emit MintTokenForProjectEvent(_to, _projectId, tokenId);
         return tokenId;
     }
 
@@ -86,5 +90,6 @@ contract OctobayGovNFT is OctobayStorage, ERC721Pausable {
 
     function burn(uint256 _tokenId) public {
         _burn(_tokenId);
+        emit BurnTokenEvent(_tokenId);
     }
 }


### PR DESCRIPTION
Looking at the subgraph implementation it seems like we really need to use events as much as possible to track what's happening with the contract for the frontend.

This is just adding a few more events for governance related things:
* Setting the governance token for an issue (bounty)
* NFT minting and burning