### PR TITLE
Fix nft gov token mapping

### DIFF
--- a/contracts/Octobay.sol
+++ b/contracts/Octobay.sol
@@ -210,14 +210,8 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
     function setGovTokenForIssue(string calldata _issueId, OctobayGovToken _govToken) public {
         // Ensure they're giving us a valid gov token
         require(bytes(octobayGovernor.projectsByToken(_govToken)).length != 0, "Invalid _govToken");
-        bool hasPermission = false;
-        uint256 govNFTId = octobayGovNFT.getTokenIDForUserByGovToken(msg.sender, _govToken);
-        if (govNFTId != 0 && octobayGovNFT.hasPermission(govNFTId, OctobayGovNFT.Permission.SET_ISSUE_GOVTOKEN)) {
-            hasPermission = true;
-        } else {
-            // Do other permission checks here, e.g. oracle calls
-        }
-        require(hasPermission, "You don't have permission to set governance tokens for issues");
+        require(octobayGovNFT.userHasPermissionForGovToken(msg.sender, _govToken, OctobayGovNFT.Permission.SET_ISSUE_GOVTOKEN), 
+            "You don't have permission to set governance tokens for issues");
         depositStorage.setGovTokenForIssue(_issueId, _govToken);
     }
 

--- a/contracts/OctobayGovNFT.sol
+++ b/contracts/OctobayGovNFT.sol
@@ -100,23 +100,19 @@ contract OctobayGovNFT is OctobayStorage, ERC721Pausable {
         return tokenId;
     }
 
-    /// TODO: I just realised a bug with this, it's possible for a user to have multiple NFTs per gov token here.
-    /// An attacker could actually mint and send an NFT with no permissions and send it to someone to 'cover' or 'hide'
-    /// their actual NFT. I suppose instead we should have a function which checks whether a user simply has a specific permission
-    /// for a given gov token and look through all of their list of NFTs.
-
-    /// @notice Checks whether a user has an NFT for a given governance token
+    /// @notice Checks whether a user has a given permission for a given governance token
     /// @param _user Address of user to check for NFT ownership
     /// @param _govToken The governance token associated with this NFT
-    /// @return If found, the ID of the NFT this user owns or 0 if none is found
-    function getTokenIDForUserByGovToken(address _user, OctobayGovToken _govToken) public view returns(uint256) {
+    /// @param _perm The permission we're checking for
+    /// @return Whether the user 
+    function userHasPermissionForGovToken(address _user, OctobayGovToken _govToken, Permission _perm) public view returns(bool) {
         for (uint i=0; i < balanceOf(_user); i++) {
             if (govTokensByTokenId[tokenOfOwnerByIndex(_user, i)] == _govToken) {
-                return tokenOfOwnerByIndex(_user, i);
+                return hasPermission(tokenOfOwnerByIndex(_user, i), _perm);
             }
         }
 
-        return 0;
+        return false;
     }
 
     /// @dev We need to override this as we don't allow transfers by default, we need to check the NFT has permission to transfer

--- a/contracts/OctobayGovNFT.sol
+++ b/contracts/OctobayGovNFT.sol
@@ -44,16 +44,6 @@ contract OctobayGovNFT is OctobayStorage, ERC721Pausable {
         _grantPermission(_tokenId, Permission.TRANSFER);
         _grantPermission(_tokenId, Permission.SET_ISSUE_GOVTOKEN);
         _grantPermission(_tokenId, Permission.CREATE_PROPOSAL);
-    }
-
-    /// @notice Revokes all permissions from the given NFT
-    /// @param _tokenId ID of the NFT to grant permissions to
-    function revokeAllPermissions(uint256 _tokenId) internal {
-        // There's no nice way of looping through enums... :( It's probably better that we do this here though
-        _revokePermission(_tokenId, Permission.MINT);
-        _revokePermission(_tokenId, Permission.TRANSFER);
-        _revokePermission(_tokenId, Permission.SET_ISSUE_GOVTOKEN);
-        _revokePermission(_tokenId, Permission.CREATE_PROPOSAL);
     }    
 
     /// @param _tokenId ID of the NFT to grant permission to
@@ -144,7 +134,10 @@ contract OctobayGovNFT is OctobayStorage, ERC721Pausable {
     /// @param _tokenId ID of the NFT to burn (destroy)
     function burn(uint256 _tokenId) public {
         delete govTokensByTokenId[_tokenId];
-        revokeAllPermissions(_tokenId);
+        _revokePermission(_tokenId, Permission.MINT);
+        _revokePermission(_tokenId, Permission.TRANSFER);
+        _revokePermission(_tokenId, Permission.SET_ISSUE_GOVTOKEN);
+        _revokePermission(_tokenId, Permission.CREATE_PROPOSAL);
         _burn(_tokenId);
         emit BurnTokenEvent(_tokenId);
     }

--- a/contracts/OctobayGovernor.sol
+++ b/contracts/OctobayGovernor.sol
@@ -108,16 +108,9 @@ contract OctobayGovernor is OctobayStorage {
         Governor storage governor = governorsByTokenAddr[_govToken];
         require(_quorum >= governor.minQuorum, "Given _quorum is less than this governor's minQuorum");
 
-        bool hasPermission = false;
-        if (_govToken.balanceOfAsPercent(msg.sender) >= governor.newProposalShare) {
-            hasPermission = true;
-        } else {
-            uint256 govNFTId = octobayGovNFT.getTokenIDForUserByGovToken(msg.sender, _govToken);
-            if (govNFTId != 0 && octobayGovNFT.hasPermission(govNFTId, OctobayGovNFT.Permission.CREATE_PROPOSAL)) {
-                hasPermission = true;
-            }
-        }
-        require(hasPermission, "Token share not high enough and no NFT permission for new proposals");
+        require((_govToken.balanceOfAsPercent(msg.sender) >= governor.newProposalShare) || 
+            (octobayGovNFT.userHasPermissionForGovToken(msg.sender, _govToken, OctobayGovNFT.Permission.CREATE_PROPOSAL)), 
+            "Token share not high enough and no NFT permission for new proposals");
         
         uint256 snapshotId = _govToken.snapshot();
         Proposal memory newProposal = Proposal({
@@ -138,7 +131,6 @@ contract OctobayGovernor is OctobayStorage {
         emit ProposalCreatedEvent(address(_govToken), _discussionId, _startDate, _endDate, _quorum, msg.sender, governor.proposalCount, snapshotId);
     }
 
-    /// @notice Anyone with at least newProposalShare share of tokens or an NFT with the required permission can create a new proposal here
     /// @param _govToken Address of the gov token to use 
     /// @param _proposalId ID of the proposal whose state we should check
     /// @return The ProposalState of the given proposal


### PR DESCRIPTION
Fixes the issue where we can only have one NFT per gov token.

If we need a list of NFTs per govToken we need to add another mapping. I looked at using this, which would make it easier to do removals: https://docs.openzeppelin.com/contracts/3.x/api/utils#EnumerableSet

But you then need to make the variable private, which means we need to write our own getter, so it's not clearly better. If we do use it though it would be useful for the list of gov tokens per projectId in OctobayGovernor as well.