### PR TITLE
Feature/update gov token params

### DIFF
--- a/contracts/Octobay.sol
+++ b/contracts/Octobay.sol
@@ -387,10 +387,10 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
     /// @param _govToken The address of the governance token for this governor
     /// @param _newProposalShare Share of gov tokens a holder requires before they can create new proposals
     /// @param _minQuorum The minimum quorum allowed for new proposals    
-    function updateNewProposalParams(OctobayGovToken _govToken, uint16 _newProposalShare, uint16 _minQuorum)
+    function updateGovTokenParams(OctobayGovToken _govToken, uint16 _newProposalShare, uint16 _minQuorum)
         public
     {
-        octobayGovernor.updateNewProposalParams(_govToken, _newProposalShare, _minQuorum, msg.sender);
+        octobayGovernor.updateGovTokenParams(_govToken, _newProposalShare, _minQuorum, msg.sender);
     }
 
     // ------------ UTILS ------------ //

--- a/contracts/Octobay.sol
+++ b/contracts/Octobay.sol
@@ -383,6 +383,16 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
         octobayGovNFT.grantAllPermissions(nftId);
     }
 
+    /// @notice A request from the site to update a governance token's params for new proposals
+    /// @param _govToken The address of the governance token for this governor
+    /// @param _newProposalShare Share of gov tokens a holder requires before they can create new proposals
+    /// @param _minQuorum The minimum quorum allowed for new proposals    
+    function updateNewProposalParams(OctobayGovToken _govToken, uint16 _newProposalShare, uint16 _minQuorum)
+        public
+    {
+        octobayGovernor.updateNewProposalParams(_govToken, _newProposalShare, _minQuorum, msg.sender);
+    }
+
     // ------------ UTILS ------------ //
 
 

--- a/contracts/OctobayGovernor.sol
+++ b/contracts/OctobayGovernor.sol
@@ -103,7 +103,7 @@ contract OctobayGovernor is OctobayStorage {
     /// @param _newProposalShare Share of gov tokens a holder requires before they can create new proposals
     /// @param _minQuorum The minimum quorum allowed for new proposals
     /// @param _msgSender The original sender
-    function updateNewProposalParams(
+    function updateGovTokenParams(
         OctobayGovToken _govToken,
         uint16 _newProposalShare,
         uint16 _minQuorum,

--- a/contracts/OctobayGovernor.sol
+++ b/contracts/OctobayGovernor.sol
@@ -50,7 +50,7 @@ contract OctobayGovernor is OctobayStorage {
 
     event DepartmentCreatedEvent(address creator, string projectId, uint16 newProposalShare, uint16 minQuorum, string tokenName, string tokenSymbol, address tokenAddress);
     
-    event UpdateNewProposalParamsEvent(address govToken, uint16 newProposalShare, uint16 minQuorum);
+    event UpdateGovTokenParamsEvent(address govToken, uint16 newProposalShare, uint16 minQuorum);
 
     /// @notice Maps gov token address to a Governor
     mapping (OctobayGovToken => Governor) public governorsByTokenAddr;
@@ -115,7 +115,7 @@ contract OctobayGovernor is OctobayStorage {
         governorsByTokenAddr[_govToken].newProposalShare = _newProposalShare;
         governorsByTokenAddr[_govToken].minQuorum = _minQuorum;
 
-        emit UpdateNewProposalParamsEvent(address(_govToken), _newProposalShare, _minQuorum);
+        emit UpdateGovTokenParamsEvent(address(_govToken), _newProposalShare, _minQuorum);
     }
 
     /// @notice Anyone with at least newProposalShare share of tokens or an NFT with the required permission can create a new proposal here

--- a/contracts/OctobayGovernor.sol
+++ b/contracts/OctobayGovernor.sol
@@ -109,7 +109,7 @@ contract OctobayGovernor is OctobayStorage {
         uint16 _minQuorum,
         address _msgSender
     ) public onlyOctobay {
-        require(governorsByTokenAddr[_govToken].isValue, "Governor does not exists");
+        require(governorsByTokenAddr[_govToken].isValue, "Governor does not exist");
         require(octobayGovNFT.userHasPermissionForGovToken(_msgSender, _govToken, OctobayGovNFT.Permission.MINT), "Not allowed to change token's parameters");
 
         governorsByTokenAddr[_govToken].newProposalShare = _newProposalShare;


### PR DESCRIPTION
A method for the frontend to update a governance tokens parameters for new proposals (`newProposalShare` and `minQuorum`).

Uses:
https://github.com/Octobay/contracts/blob/9925aa129cfabc6da55a82fed47500e85b3b1b74/contracts/OctobayGovNFT.sol#L98-L107

Needed here:
![image](https://user-images.githubusercontent.com/6792578/117585181-48456580-b111-11eb-93d0-17dd96bc3303.png)
