### PR TITLE
Use plain ERC721

### DIFF
--- a/contracts/OctobayGovNFT.sol
+++ b/contracts/OctobayGovNFT.sol
@@ -134,6 +134,7 @@ contract OctobayGovNFT is OctobayStorage, ERC721Pausable {
 
     /// @param _tokenId ID of the NFT to burn (destroy)
     function burn(uint256 _tokenId) public {
+        require(ownerOf(_tokenId) == msg.sender, "Not the owner of _tokenId");
         delete govTokensByTokenId[_tokenId];
         _revokePermission(_tokenId, Permission.MINT);
         _revokePermission(_tokenId, Permission.TRANSFER);

--- a/contracts/OctobayGovNFT.sol
+++ b/contracts/OctobayGovNFT.sol
@@ -139,7 +139,9 @@ contract OctobayGovNFT is OctobayStorage, ERC721Pausable {
         _revokePermission(_tokenId, Permission.TRANSFER);
         _revokePermission(_tokenId, Permission.SET_ISSUE_GOVTOKEN);
         _revokePermission(_tokenId, Permission.CREATE_PROPOSAL);
+        _unpause();
         _burn(_tokenId);
+        _pause();
         emit BurnTokenEvent(_tokenId);
     }
 }


### PR DESCRIPTION
The `ERC721Pausable` was becoming more hassle than useful, so I've changed the implementation to plain `ERC721` now.

The transfer is checked in `_beforeTokenTransfer` to ensure the NFT has the permission for `TRANSFER`. We could also allow transfers for `MINT` as well... but I'm not sure who is minting tokens without the transfer permission... they could just mint themselves another token anyway.

NB: This is a branch of #32 so merge that first. 