### PR TITLE
Create governance token before oracle call

### DIFF
--- a/contracts/Octobay.sol
+++ b/contracts/Octobay.sol
@@ -321,16 +321,6 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
     OctobayGovernor public octobayGovernor;
     AggregatorV3Interface internal ethUSDPriceFeed;
 
-    /// @notice Used to wrap arguments to createGovernanceToken
-    struct NewGovernanceRequest {
-        string githubUserId; // Github graphql ID of the user we need to check for ownership
-        string name; // Name of the new governance token
-        string symbol; // Symbol to use for the new governance token
-        string projectId; // Github graphql ID of the project (repo/org) to be associated with the new token
-        uint16 newProposalShare; // Share of gov tokens a holder requires before they can create new proposals
-        uint16 minQuorum; // The minimum quorum allowed for new proposals
-    }
-
     /// @notice Used to store Chainlink requests for new governance tokens
     struct TempGovernanceRequest {
         bool isValue; // Ensure we have a valid value in the map
@@ -342,6 +332,15 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
     }
 
     mapping(bytes32 => TempGovernanceRequest) public tempGovernanceReqs;
+
+    /// @notice Used to wrap arguments to createGovernanceToken
+    struct NewGovernanceRequest {
+        string name; // Name of the new governance token
+        string symbol; // Symbol to use for the new governance token
+        string projectId; // Github graphql ID of the project (repo/org) to be associated with the new token
+        uint16 newProposalShare; // Share of gov tokens a holder requires before they can create new proposals
+        uint16 minQuorum; // The minimum quorum allowed for new proposals
+    }
 
     /// @notice A request from the site to create a new governance token, checks ownership of the given
     ///         project (repo or org) via a Chainlink Oracle request to confirm
@@ -359,7 +358,7 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
                 address(this),
                 this.confirmCreateGovernanceToken.selector
             );
-        request.add('githubUserId', _newGovReq.githubUserId);
+        request.add('githubUserId', userAddressStorage.userIdsByAddress(msg.sender));
         request.add('repoOrgId', _newGovReq.projectId);
         requestId = sendChainlinkRequestTo(_oracle, request, jobFee);
 

--- a/contracts/Octobay.sol
+++ b/contracts/Octobay.sol
@@ -321,28 +321,36 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
     OctobayGovernor public octobayGovernor;
     AggregatorV3Interface internal ethUSDPriceFeed;
 
-    /// @notice Used to store Chainlink requests for new governance tokens
-    struct NewGovernanceToken {
-        bool isValue; // Ensure we have a valid value in the map
+    /// @notice Used to wrap arguments to createGovernanceToken
+    struct NewGovernanceRequest {
         string githubUserId; // Github graphql ID of the user we need to check for ownership
         string name; // Name of the new governance token
         string symbol; // Symbol to use for the new governance token
         string projectId; // Github graphql ID of the project (repo/org) to be associated with the new token
         uint16 newProposalShare; // Share of gov tokens a holder requires before they can create new proposals
         uint16 minQuorum; // The minimum quorum allowed for new proposals
-        address creator; // Address of the creator, we need to store this as we lose it in the Oracle callback otherwise
     }
 
-    mapping(bytes32 => NewGovernanceToken) public newGovernanceTokenReqs;
+    /// @notice Used to store Chainlink requests for new governance tokens
+    struct TempGovernanceRequest {
+        bool isValue; // Ensure we have a valid value in the map
+        address creator; // Address of the creator, we need to store this as we lose it in the Oracle callback otherwise
+        string projectId; // Github graphql ID of the project (repo/org) to be associated with the new token
+        uint16 newProposalShare; // Share of gov tokens a holder requires before they can create new proposals
+        uint16 minQuorum; // The minimum quorum allowed for new proposals
+        OctobayGovToken govToken; // The new governance token which needs to be confirmed
+    }
+
+    mapping(bytes32 => TempGovernanceRequest) public tempGovernanceReqs;
 
     /// @notice A request from the site to create a new governance token, checks ownership of the given
     ///         project (repo or org) via a Chainlink Oracle request to confirm
     /// @dev Using a struct as an argument here otherwise we get stack too deep errors
     /// @param _oracle Specify the address of the _oracle to use for the request
-    /// @param _newToken The details of the new governance token to create
+    /// @param _newGovReq The details of the new governor and token to create
     function createGovernanceToken(
         address _oracle,
-        NewGovernanceToken memory _newToken
+        NewGovernanceRequest memory _newGovReq
     ) public oracleHandlesJob(_oracle, 'check-ownership') returns(bytes32 requestId) {
         (bytes32 jobId, uint256 jobFee) = oracleStorage.getOracleJob(_oracle, 'check-ownership');
         Chainlink.Request memory request =
@@ -351,12 +359,18 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
                 address(this),
                 this.confirmCreateGovernanceToken.selector
             );
-        request.add('githubUserId', _newToken.githubUserId);
-        request.add('repoOrgId', _newToken.projectId);
+        request.add('githubUserId', _newGovReq.githubUserId);
+        request.add('repoOrgId', _newGovReq.projectId);
         requestId = sendChainlinkRequestTo(_oracle, request, jobFee);
 
-        _newToken.creator = msg.sender;
-        newGovernanceTokenReqs[requestId] = _newToken;
+        tempGovernanceReqs[requestId] = TempGovernanceRequest({
+            isValue: true,
+            creator: msg.sender,
+            projectId: _newGovReq.projectId,
+            newProposalShare: _newGovReq.newProposalShare,
+            minQuorum: _newGovReq.minQuorum,
+            govToken: octobayGovernor.createToken(_newGovReq.name, _newGovReq.symbol)
+        });
     }
 
     /// @notice Called in response by the Chainlink Oracle, continues with governance token creation
@@ -366,21 +380,24 @@ contract Octobay is Ownable, ChainlinkClient, BaseRelayRecipient {
         public
         recordChainlinkFulfillment(_requestId)
     {
-        require(_result, "User is not owner of organization or repository");
-        NewGovernanceToken memory newToken = newGovernanceTokenReqs[_requestId];
-        require(newToken.isValue, "No such request");
-        delete newGovernanceTokenReqs[_requestId];
+        require(tempGovernanceReqs[_requestId].isValue, "No such request");
 
-        OctobayGovToken deployedToken = octobayGovernor.createGovernorAndToken(
-            newToken.creator,
-            newToken.projectId,
-            newToken.newProposalShare,
-            newToken.minQuorum,
-            newToken.name,
-            newToken.symbol
+        if (!_result) {
+            delete tempGovernanceReqs[_requestId];
+            return;
+        }
+
+        octobayGovernor.createGovernorAndSetToken(
+            tempGovernanceReqs[_requestId].creator,
+            tempGovernanceReqs[_requestId].projectId,
+            tempGovernanceReqs[_requestId].newProposalShare,
+            tempGovernanceReqs[_requestId].minQuorum,
+            tempGovernanceReqs[_requestId].govToken
         );
-        uint256 nftId = octobayGovNFT.mintNFTForGovToken(newToken.creator, deployedToken);
+        uint256 nftId = octobayGovNFT.mintNFTForGovToken(tempGovernanceReqs[_requestId].creator, tempGovernanceReqs[_requestId].govToken);
         octobayGovNFT.grantAllPermissions(nftId);
+
+        delete tempGovernanceReqs[_requestId];
     }
 
     /// @notice A request from the site to update a governance token's params for new proposals

--- a/contracts/OctobayGovernor.sol
+++ b/contracts/OctobayGovernor.sol
@@ -61,25 +61,22 @@ contract OctobayGovernor is OctobayStorage {
         octobayGovNFT = OctobayGovNFT(_octobayGovNFT);
     }
 
-    /// @notice Essentially a wrapper for createGovernor and createToken to use only one call
+    /// @notice Essentially a wrapper for createGovernor and setTokenForProjectId to use only one call
     /// @param _projectId Github graphql ID of the org or repo this governor/token is associated with
     /// @param _newProposalShare Share of gov tokens a holder requires before they can create new proposals
     /// @param _minQuorum The minimum quorum allowed for new proposals
-    /// @param _name Name of the new governance token
-    /// @param _symbol Symbol to use for the new governance token
-    /// @return newToken A reference to the created governance token
-    function createGovernorAndToken(
+    /// @param _govToken Address of the gov token to use 
+    function createGovernorAndSetToken(
         address _creator,
         string memory _projectId,
         uint16 _newProposalShare,
         uint16 _minQuorum,
-        string memory _name,
-        string memory _symbol
-    ) external onlyOctobay returns(OctobayGovToken newToken) {
-        newToken = createToken(_name, _symbol, _projectId);
-        createGovernor(_creator, newToken, _newProposalShare, _minQuorum);
+        OctobayGovToken _govToken
+    ) external onlyOctobay {
+        setTokenForProjectId(_govToken, _projectId);
+        createGovernor(_creator, _govToken, _newProposalShare, _minQuorum);
 
-        emit DepartmentCreatedEvent(_creator, _projectId, _newProposalShare, _minQuorum, _name, _symbol, address(newToken));
+        emit DepartmentCreatedEvent(_creator, _projectId, _newProposalShare, _minQuorum, _govToken.name(), _govToken.symbol(), address(_govToken));
     } 
 
     /// @notice Necessary to set the parameters for new proposals and to know if we've already initialized a governor
@@ -209,14 +206,18 @@ contract OctobayGovernor is OctobayStorage {
 
     /// @param _name Name of the new token
     /// @param _symbol Token Symbol for the new token
-    /// @param _projectId Github graphql ID of the org or repo this governor/token is associated with
     /// @return A reference to the created governance token
-    function createToken(string memory _name, string memory _symbol, string memory _projectId) public onlyOctobay returns (OctobayGovToken) {
+    function createToken(string memory _name, string memory _symbol) public onlyOctobay returns (OctobayGovToken) {
         OctobayGovToken newToken = new OctobayGovToken(_name, _symbol);
         newToken.setOctobay(msg.sender);
-        tokensByProjectId[_projectId].push(newToken);
-        projectsByToken[newToken] = _projectId;
         return newToken;
+    }
+
+    /// @param _govToken Governance token to associate with the given project ID
+    /// @param _projectId Github graphql ID of the org or repo this governor/token should be associated with
+    function setTokenForProjectId(OctobayGovToken _govToken, string memory _projectId) public onlyOctobay {
+        tokensByProjectId[_projectId].push(_govToken);
+        projectsByToken[_govToken] = _projectId;
     }
 
     /// @notice Used in case a project wants to transfer tokens from a repo to an org in the future for example


### PR DESCRIPTION
This is intended to cover #25 

The governance token is now created before the call to the CL oracle to confirm the user is the owner/member of an org/repo. This token is then 'set' in the confirmation function called by the CL oracle. This was done to ensure the final confirmation function doesn't burn too much gas on behalf of the calling oracle.

In addition, this PR uses the githubUserId from UserAddressStorage from msg.sender. Previously the githubUserId was simply given as an argument and not checked.

The struct used to call the `createGovernanceToken` has now changed, so this will need to be updated in the frontend.