### PR TITLE
Get rid of quotes around addresses

### DIFF
--- a/deploy/deploy_superfluid.js
+++ b/deploy/deploy_superfluid.js
@@ -71,9 +71,9 @@ async function deploySuperfluid() {
 
 	console.log(ret);
 
-	const addresses = `FDAI_ADDRESS="${fDAIAddress}"
-FDAIX_ADDRESS="${fDAIxAddress}"
-SUPERFLUID_RESOLVER_ADDRESS="${process.env.RESOLVER_ADDRESS}"
+	const addresses = `FDAI_ADDRESS=${fDAIAddress}
+FDAIX_ADDRESS=${fDAIxAddress}
+SUPERFLUID_RESOLVER_ADDRESS=${process.env.RESOLVER_ADDRESS}
 `;
 
 	fs.writeFileSync('.env.superfluid.contracts', addresses);


### PR DESCRIPTION
If it makes no difference to other setups, it would help me to remove the quotes around the addresses here so that docker remains happy :)