### PR TITLE
ExtendDeposit and refundDeposit (tests+smart contract modifs)

### DIFF
--- a/contracts/Bounty/Implementations/BountyV1.sol
+++ b/contracts/Bounty/Implementations/BountyV1.sol
@@ -526,6 +526,32 @@ contract BountyV1 is BountyStorageV1 {
     }
 
     /**
+     * @dev Returns the amount of available tokens (of a specific token) on a bounty address, not locked in deposits and available for refund
+     * @param _bountyAddress Address of bounty
+     * @param _depToken The depositId that determines which token is being looked at
+     * @return uint256
+     */
+    function getAvailableFunds(address _bountyAddress, address _depToken)
+        public
+        view
+        returns (uint256)
+    {
+        BountyV1 bounty = BountyV1(payable(_bountyAddress));
+
+        uint256 lockedFunds;
+        bytes32[] memory depList = bounty.getDeposits();
+        for (uint256 i = 0; i < depList.length; i++) {
+            if(block.timestamp <
+                bounty.depositTime(depList[i]) + bounty.expiration(depList[i])
+                && bounty.tokenAddress(depList[i]) == _depToken
+                )
+            { lockedFunds += bounty.volume(depList[i]); }   
+        }
+
+        return lockedFunds;
+    }
+
+    /**
      * @dev Transfers _volume of both ERC20 or protocol token to _payoutAddress
      * @param _tokenAddress Address of an ERC20 or Zero Address for protocol token
      * @param _volume Volume to transfer

--- a/contracts/Bounty/Implementations/BountyV1.sol
+++ b/contracts/Bounty/Implementations/BountyV1.sol
@@ -340,8 +340,13 @@ contract BountyV1 is BountyStorageV1 {
         require(status == 0, Errors.CONTRACT_IS_CLOSED);
         require(refunded[_depositId] == false, Errors.DEPOSIT_ALREADY_REFUNDED);
         require(funder[_depositId] == _funder, Errors.CALLER_NOT_FUNDER);
-
-        expiration[_depositId] = expiration[_depositId] + _seconds;
+        
+        if(block.timestamp > depositTime[_depositId] + expiration[_depositId]) {
+            expiration[_depositId] = block.timestamp - depositTime[_depositId] + _seconds;
+        } else {
+            expiration[_depositId] = expiration[_depositId] + _seconds;
+        }
+        
 
         return expiration[_depositId];
     }

--- a/contracts/Bounty/Implementations/BountyV1.sol
+++ b/contracts/Bounty/Implementations/BountyV1.sol
@@ -526,12 +526,12 @@ contract BountyV1 is BountyStorageV1 {
     }
 
     /**
-     * @dev Returns the amount of available tokens (of a specific token) on a bounty address, not locked in deposits and available for refund
+     * @dev Returns the amount of locked tokens (of a specific token) on a bounty address, only available for claims but not for refunds
      * @param _bountyAddress Address of bounty
      * @param _depToken The depositId that determines which token is being looked at
      * @return uint256
      */
-    function getAvailableFunds(address _bountyAddress, address _depToken)
+    function getLockedFunds(address _bountyAddress, address _depToken)
         public
         view
         returns (uint256)

--- a/contracts/Bounty/Implementations/BountyV1.sol
+++ b/contracts/Bounty/Implementations/BountyV1.sol
@@ -291,8 +291,9 @@ contract BountyV1 is BountyStorageV1 {
      * @dev Transfers volume of deposit or NFT of deposit from bounty to funder
      * @param _depositId The deposit to refund
      * @param _funder The initial funder of the deposit
+     * @param _volume The volume to be refunded
      */
-    function refundDeposit(bytes32 _depositId, address _funder)
+    function refundDeposit(bytes32 _depositId, address _funder, uint256 _volume)
         external
         onlyDepositManager
         nonReentrant
@@ -310,7 +311,7 @@ contract BountyV1 is BountyStorageV1 {
 
         // Interactions
         if (tokenAddress[_depositId] == address(0)) {
-            _transferProtocolToken(funder[_depositId], volume[_depositId]);
+            _transferProtocolToken(funder[_depositId], _volume);
         } else if (isNFT[_depositId]) {
             _transferNft(
                 tokenAddress[_depositId],
@@ -321,7 +322,7 @@ contract BountyV1 is BountyStorageV1 {
             _transferERC20(
                 tokenAddress[_depositId],
                 funder[_depositId],
-                volume[_depositId]
+                _volume
             );
         }
     }

--- a/contracts/DepositManager/DepositManager.sol
+++ b/contracts/DepositManager/DepositManager.sol
@@ -173,7 +173,7 @@ contract DepositManager is DepositManagerStorageV1 {
         
         address depToken = bounty.tokenAddress(_depositId);
 
-        uint256 availableFunds = bounty.getTokenBalance(depToken) - bounty.getAvailableFunds(_bountyAddress, depToken);
+        uint256 availableFunds = bounty.getTokenBalance(depToken) - bounty.getLockedFunds(_bountyAddress, depToken);
         
         uint256 volume;
         if (bounty.volume(_depositId) <= availableFunds ) {

--- a/contracts/DepositManager/DepositManager.sol
+++ b/contracts/DepositManager/DepositManager.sol
@@ -152,7 +152,7 @@ contract DepositManager is DepositManagerStorageV1 {
     /**
      * @dev Refunds an individual deposit from bountyAddress to sender if expiration time has passed
      * @param _bountyAddress Bounty address
-     * @param _depositId The depositId assocaited with the deposit being refunded
+     * @param _depositId The depositId associated with the deposit being refunded
      */
     function refundDeposit(address _bountyAddress, bytes32 _depositId)
         external
@@ -172,17 +172,8 @@ contract DepositManager is DepositManagerStorageV1 {
         );
         
         address depToken = bounty.tokenAddress(_depositId);
-        uint256 lockedFunds;
-        bytes32[] memory depList = bounty.getDeposits();
-        for (uint256 i = 0; i < depList.length; i++) {
-            if(block.timestamp <
-                bounty.depositTime(depList[i]) + bounty.expiration(depList[i])
-                && bounty.tokenAddress(depList[i]) == depToken
-                )
-            { lockedFunds += bounty.volume(depList[i]); }   
-        }
 
-        uint256 availableFunds = bounty.getTokenBalance(depToken) - lockedFunds;
+        uint256 availableFunds = bounty.getTokenBalance(depToken) - bounty.getAvailableFunds(_bountyAddress, depToken);
         
         uint256 volume;
         if (bounty.volume(_depositId) <= availableFunds ) {

--- a/test/BountyV1.test.js
+++ b/test/BountyV1.test.js
@@ -514,7 +514,7 @@ describe('BountyV1.sol', () => {
 				const mockDepositId = generateDepositId(owner.address, mockLink.address, 123);
 
 				// ASSERT
-				await expect(issueWithNonOwnerAccount.refundDeposit(mockDepositId, owner.address)).to.be.revertedWith('DepositManagerOwnable: caller is not the current OpenQ Deposit Manager');
+				await expect(issueWithNonOwnerAccount.refundDeposit(mockDepositId, owner.address, 100)).to.be.revertedWith('DepositManagerOwnable: caller is not the current OpenQ Deposit Manager');
 			});
 
 			it('should revert if called before expiration', async () => {
@@ -526,7 +526,7 @@ describe('BountyV1.sol', () => {
 				await atomicContract.connect(depositManager).receiveFunds(owner.address, mockLink.address, volume, 10000);
 
 				// ACT
-				await expect(atomicContract.connect(depositManager).refundDeposit(linkDepositId, owner.address)).to.be.revertedWith('PREMATURE_REFUND_REQUEST');
+				await expect(atomicContract.connect(depositManager).refundDeposit(linkDepositId, owner.address, volume)).to.be.revertedWith('PREMATURE_REFUND_REQUEST');
 			});
 		});
 
@@ -549,9 +549,9 @@ describe('BountyV1.sol', () => {
 				expect(await atomicContract.refunded(protocolDepositId)).to.equal(false);
 
 				// ACT
-				await atomicContract.connect(depositManager).refundDeposit(linkDepositId, owner.address);
-				await atomicContract.connect(depositManager).refundDeposit(daiDepositId, owner.address);
-				await atomicContract.connect(depositManager).refundDeposit(protocolDepositId, owner.address);
+				await atomicContract.connect(depositManager).refundDeposit(linkDepositId, owner.address, volume);
+				await atomicContract.connect(depositManager).refundDeposit(daiDepositId, owner.address, volume);
+				await atomicContract.connect(depositManager).refundDeposit(protocolDepositId, owner.address, volume);
 
 				// ASSERT
 				expect(await atomicContract.refunded(linkDepositId)).to.equal(true);
@@ -589,8 +589,8 @@ describe('BountyV1.sol', () => {
 				expect(funderFakeTokenBalance).to.equal('9999999999999999999900');
 
 				// // // ACT
-				await atomicContract.connect(depositManager).refundDeposit(linkDepositId, owner.address);
-				await atomicContract.connect(depositManager).refundDeposit(daiDepositId, owner.address);
+				await atomicContract.connect(depositManager).refundDeposit(linkDepositId, owner.address, volume);
+				await atomicContract.connect(depositManager).refundDeposit(daiDepositId, owner.address, volume);
 
 				// // // // ASSERT
 				const newBountyMockLinkBalance = (await mockLink.balanceOf(atomicContract.address)).toString();
@@ -616,7 +616,7 @@ describe('BountyV1.sol', () => {
 				expect(await mockNft.ownerOf(1)).to.equal(atomicContract.address);
 
 				// ACT
-				await atomicContract.connect(depositManager).refundDeposit(depositId, owner.address);
+				await atomicContract.connect(depositManager).refundDeposit(depositId, owner.address, 0);
 
 				// ASSERT
 				expect(await mockNft.ownerOf(1)).to.equal(owner.address);
@@ -638,7 +638,7 @@ describe('BountyV1.sol', () => {
 
 			// ASSERT
 			// This will fail to revert without a deposit extension. Cannot test the counter case due to the inability to call refund twice, see DEPOSIT_ALREADY_REFUNDED
-			await expect(atomicContract.connect(depositManager).refundDeposit(linkDepositId, owner.address)).to.be.revertedWith('PREMATURE_REFUND_REQUEST');
+			await expect(atomicContract.connect(depositManager).refundDeposit(linkDepositId, owner.address, volume)).to.be.revertedWith('PREMATURE_REFUND_REQUEST');
 		});
 	});
 

--- a/test/DepositManager.test.js
+++ b/test/DepositManager.test.js
@@ -593,17 +593,10 @@ describe('DepositManager.sol', () => {
 
 			it('should revert if not funder', async () => {
 				// ARRANGE
-				// Mint Bounty
+				// Mint Bounty & generate Deposit
 				await openQProxy.mintBounty(bountyId, mockOrg, atomicBountyInitOperation);
 				const bountyAddress = await openQProxy.bountyIdToAddress(bountyId);
-
-				// Get Escrow Period
-				bounty = await BountyV1.attach(bountyAddress);
-
-				const expectedTimestamp = await setNextBlockTimestamp();
-				const depositId = generateDepositId(bountyId, 0); // ? 
-
-				const escrowPeriod = await bounty.expiration(depositId);// ?
+				const depositId = generateDepositId(bountyId, 0);
 
 				// ADVANCE TIME
 				const thirtyTwoDays = 2765000;

--- a/test/DepositManager.test.js
+++ b/test/DepositManager.test.js
@@ -573,6 +573,47 @@ describe('DepositManager.sol', () => {
 				.to.emit(depositManager, 'DepositExtended')
 				.withArgs(depositId, 1001, 0, [], 1);
 		});
+
+		describe('requires and reverts', () => {
+			/* it('should revert if new deadline earlier than deposit lock deadline', async () => {
+				// Mint Bounty
+				await openQProxy.mintBounty(bountyId, mockOrg, atomicBountyInitOperation);
+				const bountyAddress = await openQProxy.bountyIdToAddress(bountyId);
+				const Bounty = await ethers.getContractFactory('BountyV1');
+				const bounty = await Bounty.attach(bountyAddress);
+
+				await mockLink.approve(bountyAddress, 10000000);
+				await depositManager.fundBountyToken(bountyAddress, mockLink.address, 100, 1);
+
+				const depositId = generateDepositId(bountyId, 0);
+
+				// ACT / ASSERT
+				await expect(depositManager.extendDeposit(bountyAddress, depositId)).to.be.revertedWith('PREMATURE_REFUND_REQUEST');
+			}); */
+
+			it('should revert if not funder', async () => {
+				// ARRANGE
+				// Mint Bounty
+				await openQProxy.mintBounty(bountyId, mockOrg, atomicBountyInitOperation);
+				const bountyAddress = await openQProxy.bountyIdToAddress(bountyId);
+
+				// Get Escrow Period
+				bounty = await BountyV1.attach(bountyAddress);
+
+				const expectedTimestamp = await setNextBlockTimestamp();
+				const depositId = generateDepositId(bountyId, 0); // ? 
+
+				const escrowPeriod = await bounty.expiration(depositId);// ?
+
+				// ADVANCE TIME
+				const thirtyTwoDays = 2765000;
+				ethers.provider.send("evm_increaseTime", [thirtyTwoDays]);
+
+				// ACT / ASSERT
+				await expect(depositManager.extendDeposit(bountyAddress, depositId, thirtyTwoDays)).to.be.revertedWith('CALLER_NOT_FUNDER');
+			});
+		});
+
 	});
 
 });

--- a/test/DepositManager.test.js
+++ b/test/DepositManager.test.js
@@ -587,10 +587,15 @@ describe('DepositManager.sol', () => {
 			await depositManager.fundBountyToken(bountyAddress, mockLink.address, 100, 864000);
 			const depositId = generateDepositId(bountyId, 0);
 
+			// ADVANCE TIME
+			const thirtyTwoDays = 2765000;
+			ethers.provider.send("evm_increaseTime", [thirtyTwoDays]);
+
 			// ACT / ASSERT
 			// deposit extension of 0 days 
-			await depositManager.extendDeposit(bountyAddress, depositId, 0);
+			await depositManager.extendDeposit(bountyAddress, depositId, 1);
 			const escrowPeriod = await bounty.expiration(depositId);
+			console.log(escrowPeriod);
 			expect(escrowPeriod).to.be.at.least(864000);
 		});
 

--- a/test/DepositManager.test.js
+++ b/test/DepositManager.test.js
@@ -593,24 +593,14 @@ describe('DepositManager.sol', () => {
 
 			it('should revert if not funder', async () => {
 				// ARRANGE
-				// Mint Bounty
+				// Mint Bounty & generate Deposit
 				await openQProxy.mintBounty(bountyId, mockOrg, atomicBountyInitOperation);
 				const bountyAddress = await openQProxy.bountyIdToAddress(bountyId);
+				const depositId = generateDepositId(bountyId, 0);
 
-				// Get Escrow Period
-				bounty = await BountyV1.attach(bountyAddress);
-
-				const expectedTimestamp = await setNextBlockTimestamp();
-				const depositId = generateDepositId(bountyId, 0); // ? 
-
-				const escrowPeriod = await bounty.expiration(depositId);// ?
-
-				// ADVANCE TIME
-				const thirtyTwoDays = 2765000;
-				ethers.provider.send("evm_increaseTime", [thirtyTwoDays]);
-
-				// ACT / ASSERT
-				await expect(depositManager.extendDeposit(bountyAddress, depositId, thirtyTwoDays)).to.be.revertedWith('CALLER_NOT_FUNDER');
+				// ACT / ASSERT 
+				// random deposit extension of 10 days 
+				await expect(depositManager.extendDeposit(bountyAddress, depositId, 864000)).to.be.revertedWith('CALLER_NOT_FUNDER');
 			});
 		});
 

--- a/test/DepositManager.test.js
+++ b/test/DepositManager.test.js
@@ -725,6 +725,60 @@ describe('DepositManager.sol', () => {
 
 	});
 
+	describe('getLockedFunds helper', () => {
+		it('should return total locked funds on bounty for a specific token (funds only available for claims)', async () => {
+			// ARRANGE
+				// Testing scenario: 
+				// 1 refundable deposit of 100 and one locked deposit of 100 => locked funds = 100
+				// Claimant gets 50 => locked funds = 100
+				// 1 new locked deposit of 100 => locked funds of 200 
+
+				await openQProxy.mintBounty(bountyId, mockOrg, ongoingBountyInitOperation);
+
+				const bountyAddress = await openQProxy.bountyIdToAddress(bountyId);
+				const Bounty = await ethers.getContractFactory('BountyV1');
+				const bounty = await Bounty.attach(bountyAddress);
+
+				await mockLink.approve(bountyAddress, 10000000);
+				const volume = 100;
+
+				// 1 refundable deposit of 100 and 1 locked of 100 
+				const linkDepositId = generateDepositId(bountyId, 0);
+				await depositManager.fundBountyToken(bountyAddress, mockLink.address, volume, 1);
+				const linkDepositId2 = generateDepositId(bountyId, 1);
+				await depositManager.fundBountyToken(bountyAddress, mockLink.address, volume, 3000000);
+
+				// ASSUME
+				const thirtyTwoDays = 2765000;
+				ethers.provider.send("evm_increaseTime", [thirtyTwoDays]);
+				
+				const bountyMockTokenBalance = (await bounty.getLockedFunds(bountyAddress, mockLink.address)).toString();
+				expect(bountyMockTokenBalance).to.equal('100');
+
+				const newBounty = await Bounty.attach(
+					bountyAddress
+				);
+				
+				// Claim of 50
+				// ACT
+				await claimManager.connect(oracle).claimBounty(bountyAddress, claimant.address, abiEncodedOngoingCloserData);
+
+				// ASSERT
+				const bountyMockTokenBalance2 = (await bounty.getLockedFunds(bountyAddress, mockLink.address)).toString();
+				expect(bountyMockTokenBalance2).to.equal('100');
+
+				// Additional locked deposit of 100
+				// ACT
+				const linkDepositId3 = generateDepositId(bountyId, 2);
+				await depositManager.fundBountyToken(bountyAddress, mockLink.address, volume, 3000000);
+				
+				// ASSERT
+				const bountyMockTokenBalance3 = (await bounty.getLockedFunds(bountyAddress, mockLink.address)).toString();
+				expect(bountyMockTokenBalance3).to.equal('200');
+
+		})
+	});
+
 });
 
 async function setNextBlockTimestamp(timestamp = 10) {


### PR DESCRIPTION
related to PR: https://github.com/OpenQDev/OpenQ-Frontend/pull/721

- Adds 3 tests for extendDeposit logic
- Modifies related smart contract to allow deposit extension when not expired yet and make sure it extends from current time (and not expiration date) when expired 

closes https://github.com/OpenQDev/OpenQ-Frontend/issues/675

- Adds a test for refundDeposit in the case of ongoing contracts
- modifies DepositManager and BountyV1 to allow for partial refunds, BUT leaving locked funds intact to be used for claims only, not for refunds
- adds a helper function to determine the locked funds, and a test for it in DepositManager.test.js