### PR TITLE
Fix review claim event spoof

### DIFF
--- a/contracts/ClaimManager/Implementations/ClaimManagerV1.sol
+++ b/contracts/ClaimManager/Implementations/ClaimManagerV1.sol
@@ -301,11 +301,11 @@ contract ClaimManagerV1 is ClaimManagerStorageV1 {
         return keccak256(abi.encodePacked(bountyId)) != emptyString;
     }
 
-    function pause() external onlyOwner whenNotPaused {
+    function pause() external onlyProxy onlyOwner whenNotPaused {
         _pause();
     }
 
-    function unpause() external onlyOwner whenPaused {
+    function unpause() external onlyProxy onlyOwner whenPaused {
         _unpause();
     }
 }

--- a/contracts/ClaimManager/Implementations/ClaimManagerV1.sol
+++ b/contracts/ClaimManager/Implementations/ClaimManagerV1.sol
@@ -65,8 +65,6 @@ contract ClaimManagerV1 is ClaimManagerStorageV1 {
                 _closerData,
                 VERSION_1
             );
-        } else if (_bountyType == OpenQDefinitions.TIERED_FIXED) {
-            _claimTieredFixedBounty(bounty, _closer, _closerData);
         } else {
             revert(Errors.UNKNOWN_BOUNTY_TYPE);
         }

--- a/contracts/ClaimManager/Implementations/ClaimManagerV1.sol
+++ b/contracts/ClaimManager/Implementations/ClaimManagerV1.sol
@@ -41,7 +41,7 @@ contract ClaimManagerV1 is ClaimManagerStorageV1 {
         address _bountyAddress,
         address _closer,
         bytes calldata _closerData
-    ) external onlyOracle onlyProxy {
+    ) external onlyOracle onlyProxy whenNotPaused {
         IBounty bounty = IBounty(payable(_bountyAddress));
 
         require(bountyExists(_bountyAddress), Errors.NO_EMPTY_BOUNTY_ID);


### PR DESCRIPTION
- Add the same `bountyExists` check that protects against event spoofing in `DepositManagerV1` to the ClaimManagerV1 methods `permissionedClaimTieredBounty(address,bytes)` and `claimBounty(address,address,bytes)`

- Adds `onlyProxy` to `ClaimManagerV1::pause` and `ClaimManagerV1::unpause`

- Remove codepath to call `_claimTieredFixedBounty` from the `onlyOracle` `ClaimManagerV1::claimBounty` method. There is no scenario where this would be needed right now, and introduced the ability to drain contracts in the event of an oracle compromise.

- Adds `whenNotPaused` to `ClaimManagerV1::claimBounty`

Closes #134 